### PR TITLE
Python3 support

### DIFF
--- a/flask_inputs/inputs.py
+++ b/flask_inputs/inputs.py
@@ -1,6 +1,7 @@
 
 import collections
 from itertools import chain
+from future.utils import iteritems
 
 from werkzeug.datastructures import MultiDict
 
@@ -31,7 +32,7 @@ class Inputs(object):
                 fields = dict()
 
                 if isinstance(input, dict):
-                    for field, validators in input.iteritems():
+                    for field, validators in iteritems(input):
                         fields[field] = Field(validators=validators)
                 elif isinstance(input, collections.Iterable):
                     fields['_input'] = Field(validators=input)
@@ -66,7 +67,7 @@ class Inputs(object):
         """
         success = True
 
-        for attribute, form in self._forms.iteritems():
+        for attribute, form in iteritems(self._forms):
             if '_input' in form._fields:
                 form.process(self._get_values(attribute, coerse=False))
             else:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ Flask==0.10.1
 jsonschema==2.5.1
 nose==1.3.7
 WTForms==2.0.2
+future==0.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==0.10.1
 WTForms==2.0.2
+future==0.16.0

--- a/tests/test_values.py
+++ b/tests/test_values.py
@@ -44,4 +44,5 @@ class ArgsTest(unittest.TestCase):
             inputs = ValuesInputs(request)
             inputs.validate()
 
-            self.assertEqual(inputs.errors, ['Name is required.', 'Email must be valid.'])
+            self.assertIn('Name is required.', inputs.errors)
+            self.assertIn('Email must be valid.', inputs.errors)


### PR DESCRIPTION
This PR adds Python3 support (And therefore fixes https://github.com/nathancahill/flask-inputs/issues/7) by replacing `dict.iteritems` calls with `iteritems(dict)` calls.

The `iteritems` function is obtained from `future` package. This is the way that PEP 469 suggests (https://www.python.org/dev/peps/pep-0469/) to migrate away from Python 2's `dict.iteritems`.

Also the `ArgsTest` was failing sometimes because the order in `inputs.errors` was reversed. I created more robust assertions for that.