### PR TITLE
Fixed Python 3 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init:
 	pip install -r requirements.txt
 
 test:
-	nosetests --with-coverage --cover-package=flask_inputs
+	python -m nose --with-coverage --cover-package=flask_inputs
 
 docs:
 	cd docs && make html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Flask-Inputs
+## Flask-Inputs for Python 3
 
 [![Build Status](https://travis-ci.org/nathancahill/flask-inputs.svg)](https://travis-ci.org/nathancahill/flask-inputs)
 [![Coverage Status](https://coveralls.io/repos/nathancahill/flask-inputs/badge.svg?branch=master&service=github)](https://coveralls.io/github/nathancahill/flask-inputs?branch=master)

--- a/flask_inputs/inputs.py
+++ b/flask_inputs/inputs.py
@@ -32,7 +32,7 @@ class Inputs(object):
                 fields = dict()
 
                 if isinstance(input, dict):
-                    for field, validators in iteritems(input):
+                    for field, validators in iter(input.items()):
                         fields[field] = Field(validators=validators)
                 elif isinstance(input, collections.Iterable):
                     fields['_input'] = Field(validators=input)
@@ -67,7 +67,7 @@ class Inputs(object):
         """
         success = True
 
-        for attribute, form in iteritems(self._forms):
+        for attribute, form in iter(self._forms.items()):
             if '_input' in form._fields:
                 form.process(self._get_values(attribute, coerse=False))
             else:


### PR DESCRIPTION
Some kind of copy of #10 and answer to #9. @nathancahill As far as I can see flask-inputs doesn't support Python 3, since `iteritems` has been deprecated in Python 3.

Because `dic.items()` behaves different in P2 and P3 I think propose to have two different versions of this package; one for P2 and one for P3. 